### PR TITLE
fix: update canonical and metadata URLs for blog

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,15 +8,15 @@
   <!-- SEO Meta Tags -->
   <meta name="description" content="Diary of Sankey blog posts" />
   <meta name="author" content="Sanket Bhat" />
-  <link rel="canonical" href="https://diary.devsanket.com/blog" />
+  <link rel="canonical" href="https://blog.devsanket.com/blog" />
   
   <!-- Open Graph -->
   <meta property="og:type" content="website" />
   <meta property="og:title" content="Blog" />
   <meta property="og:description" content="Diary of Sankey blog posts" />
-  <meta property="og:url" content="https://diary.devsanket.com/blog" />
+  <meta property="og:url" content="https://blog.devsanket.com/blog" />
   <meta property="og:site_name" content="Diary of Sankey" />
-  <meta property="og:image" content="https://diary.devsanket.com/og-images/default.png" />
+  <meta property="og:image" content="https://blog.devsanket.com/og-images/default.png" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
   <meta property="og:image:type" content="image/png" />
@@ -26,7 +26,7 @@
   <meta name="twitter:title" content="Blog" />
   <meta name="twitter:description" content="Diary of Sankey blog posts" />
   <meta name="twitter:creator" content="@SanketBhat11" />
-  <meta name="twitter:image" content="https://diary.devsanket.com/og-images/default.png" />
+  <meta name="twitter:image" content="https://blog.devsanket.com/og-images/default.png" />
   
   <!-- Favicon -->
   <link rel="icon" href="/images/logo.png" />
@@ -55,7 +55,7 @@
     gtag("js", new Date());
     gtag("config", "G-BGDKXKTPBQ", {
       page_title: "Blog",
-      page_location: "https://diary.devsanket.com/blog",
+      page_location: "https://blog.devsanket.com/blog",
       // Enhanced tracking
       send_page_view: true,
       allow_google_signals: true,
@@ -72,7 +72,7 @@
   
   
   <!-- RSS Feed -->
-  <link rel="alternate" type="application/rss+xml" title="Diary of Sankey RSS Feed" href="https://diary.devsanket.com/rss.xml" />
+  <link rel="alternate" type="application/rss+xml" title="Diary of Sankey RSS Feed" href="https://blog.devsanket.com/rss.xml" />
   
   <!-- JSON-LD Structured Data -->
 </head>


### PR DESCRIPTION
This pull request updates the URLs in the `index.html` file to reflect a domain change from `diary.devsanket.com` to `blog.devsanket.com`. These changes ensure consistency across canonical links, Open Graph metadata, Twitter metadata, Google Analytics configuration, and the RSS feed.

### Domain updates in `index.html`:

* Updated the `canonical` link to use the new domain `blog.devsanket.com` instead of `diary.devsanket.com`.
* Updated Open Graph metadata (`og:url` and `og:image`) to reflect the new domain.
* Updated Twitter metadata (`twitter:image`) to use the new domain.
* Updated the `page_location` in the Google Analytics configuration to point to the new domain.
* Updated the RSS feed link to use the new domain.