### PR TITLE
feat: add robots.txt generation with NO_INDEX control

### DIFF
--- a/env.example
+++ b/env.example
@@ -64,6 +64,10 @@ ENABLE_SEARCH=true
 ENABLE_RSS=true
 ENABLE_SITEMAP=true
 
+# Robots control
+# If set to true, robots.txt will disallow all crawling (useful for previews)
+NO_INDEX=false
+
 # Vercel Deployment (set in Vercel dashboard)
 # VERCEL=1
 # VERCEL_ENV=production


### PR DESCRIPTION
This pull request adds automated generation of the `robots.txt` file during the site build process, with logic to control search engine indexing based on environment variables and deployment context. The changes ensure that `robots.txt` is always up-to-date and configurable for preview or production environments.

**Robots.txt generation and indexing control:**

* Added a new environment variable `NO_INDEX` to `env.example` to control whether search engines are allowed to crawl the site. If set to `true`, all crawling is disallowed (useful for previews).
* Updated the site build script (`scripts/build-site.js`) to always (re)generate `robots.txt` as part of the build process.

**Implementation details:**

* Added `generateRobotsTxtIncremental` and `generateRobotsTxt` methods to the `SiteBuilder` class, which handle incremental and full generation of `robots.txt` based on environment variables and deployment context (e.g., Vercel preview vs. production).
* The generated `robots.txt` will include a reference to the sitemap if enabled and configured, and will either allow or disallow all crawling depending on the environment.